### PR TITLE
Fork igneous-systems/cri-o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,10 @@ crio: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/crio $(PROJECT))
 		$(PROJECT)/cmd/crio
 
 crioctl: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/crioctl $(PROJECT))
-	$(GO) build -o $@ $(PROJECT)/cmd/crioctl
+	$(GO) build -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/crioctl
 
 kpod: .gopathok $(shell hack/find-godeps.sh $(GOPKGDIR) cmd/kpod $(PROJECT))
-	$(GO) build $(LDFLAGS) -o $@ $(PROJECT)/cmd/kpod
+	$(GO) build -tags "$(BUILDTAGS)" $(LDFLAGS) -o $@ $(PROJECT)/cmd/kpod
 
 crio.conf: crio
 	./crio --config="" config --default > crio.conf

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ unexport GOBIN
 endif
 GOPKGDIR := $(GOPATH)/src/$(PROJECT)
 GOPKGBASEDIR := $(shell dirname "$(GOPKGDIR)")
+GOPKGBASENAME := $(shell basename "$(GOPKGDIR)")
 
 # Update VPATH so make finds .gopathok
 VPATH := $(VPATH):$(GOPATH)
@@ -47,7 +48,7 @@ help:
 .gopathok:
 ifeq ("$(wildcard $(GOPKGDIR))","")
 	mkdir -p "$(GOPKGBASEDIR)"
-	ln -s "$(CURDIR)" "$(GOPKGBASEDIR)"
+	ln -s "$(CURDIR)" "$(GOPKGBASEDIR)/$(GOPKGBASENAME)"
 endif
 	touch "$(GOPATH)/.gopathok"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This is the Igneous fork of [github.com/kubernetes-incubator/cri-o].  This repo
+contains customizations that are not (yet) upstream. We vendor this repo into
+our product codebase.  We provide no support for this repo.
+
 ![cri-o logo](https://cdn.rawgit.com/kubernetes-incubator/cri-o/master/logo/crio-logo.svg)
 # cri-o - OCI-based implementation of Kubernetes Container Runtime Interface
 

--- a/iggybot_config/jobs/build.yaml
+++ b/iggybot_config/jobs/build.yaml
@@ -1,0 +1,13 @@
+description: Build
+
+slavetypes:
+    - c3.xlarge
+
+steps:
+    - Checkout
+
+    - ShellCommand:
+        command: >
+            PATH=$PATH:/usr/src/go1.8/go/bin annotate-output
+            make install.tools docs all
+        maxTime: 2400

--- a/iggybot_config/phases/build.yaml
+++ b/iggybot_config/phases/build.yaml
@@ -1,0 +1,7 @@
+description: Build kubernetes-incubator/cri-o
+
+pr: True
+quartz: 0
+
+jobs:
+    - build


### PR DESCRIPTION
Forking the upstream repo to backport some fixes to the version of cri-o Igneous uses.  Also adds configuration for the Igneous build system.