### PR TITLE
Fix perpetual ContainerCreating

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -442,7 +442,9 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		}
 	}
 
-	c.ContainerStateFromDisk(scontainer)
+	if err := c.ContainerStateFromDisk(scontainer); err != nil {
+		return fmt.Errorf("error reading sandbox state from disk %q: %v", scontainer.ID(), err)
+	}
 	sb.SetCreated()
 
 	if err = label.ReserveLabel(processLabel); err != nil {
@@ -552,7 +554,9 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	spp := m.Annotations[annotations.SeccompProfilePath]
 	ctr.SetSeccompProfilePath(spp)
 
-	c.ContainerStateFromDisk(ctr)
+	if err := c.ContainerStateFromDisk(ctr); err != nil {
+		return fmt.Errorf("error reading container state from disk %q: %v", ctr.ID(), err)
+	}
 	ctr.SetCreated()
 
 	c.AddContainer(ctr)
@@ -569,9 +573,9 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 	if err := ctr.FromDisk(); err != nil {
 		return err
 	}
-	// ignore errors, this is a best effort to have up-to-date info about
-	// a given container before its state gets stored
-	c.runtime.UpdateStatus(ctr)
+	if err := c.runtime.UpdateStatus(ctr); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -579,9 +583,9 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 // ContainerStateToDisk writes the container's state information to a JSON file
 // on disk
 func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
-	// ignore errors, this is a best effort to have up-to-date info about
-	// a given container before its state gets stored
-	c.Runtime().UpdateStatus(ctr)
+	if err := c.Runtime().UpdateStatus(ctr); err != nil {
+		logrus.Warnf("error updating the container status %q: %v", ctr.ID(), err)
+	}
 
 	jsonSource, err := ioutils.NewAtomicFileWriter(ctr.StatePath(), 0644)
 	if err != nil {

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -443,6 +443,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	}
 
 	c.ContainerStateFromDisk(scontainer)
+	sb.SetCreated()
 
 	if err = label.ReserveLabel(processLabel); err != nil {
 		return err
@@ -552,6 +553,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 	ctr.SetSeccompProfilePath(spp)
 
 	c.ContainerStateFromDisk(ctr)
+	ctr.SetCreated()
 
 	c.AddContainer(ctr)
 	return c.ctrIDIndex.Add(id)

--- a/lib/sandbox/history.go
+++ b/lib/sandbox/history.go
@@ -16,7 +16,7 @@ func (history *History) Len() int {
 func (history *History) Less(i, j int) bool {
 	sandboxes := *history
 	// FIXME: state access should be serialized
-	return sandboxes[j].created.Before(sandboxes[i].created)
+	return sandboxes[j].createdAt.Before(sandboxes[i].createdAt)
 }
 
 // Swap switches sandboxes i and j positions in the history.

--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -96,11 +96,12 @@ type Sandbox struct {
 	hostnamePath   string
 	hostname       string
 	portMappings   []*hostport.PortMapping
+	created        bool
 	stopped        bool
 	// ipv4 or ipv6 cache
 	ip                 string
 	seccompProfilePath string
-	created            time.Time
+	createdAt          time.Time
 	hostNetwork        bool
 }
 
@@ -146,7 +147,7 @@ func New(id, namespace, name, kubeName, logDir string, labels, annotations map[s
 	sb.resolvPath = resolvPath
 	sb.hostname = hostname
 	sb.portMappings = portMappings
-	sb.created = time.Now()
+	sb.createdAt = time.Now()
 	sb.hostNetwork = hostNetwork
 
 	return sb, nil
@@ -423,4 +424,14 @@ func (s *Sandbox) NetNsRemove() error {
 	}
 
 	return s.netns.Remove()
+}
+
+// SetCreated sets the created status of sandbox to true
+func (s *Sandbox) SetCreated() {
+	s.created = true
+}
+
+// Created returns the created status of sandbox
+func (s *Sandbox) Created() bool {
+	return s.created
 }

--- a/oci/container.go
+++ b/oci/container.go
@@ -36,6 +36,7 @@ type Container struct {
 	stdinOnce       bool
 	privileged      bool
 	trusted         bool
+	created         bool
 	state           *ContainerState
 	metadata        *pb.ContainerMetadata
 	opLock          sync.Locker
@@ -291,4 +292,14 @@ func (c *Container) IDMappings() *idtools.IDMappings {
 // XXX: DO NOT EVER USE THIS, THIS IS JUST USEFUL FOR MOCKING!!!
 func (c *Container) SetState(state *ContainerState) {
 	c.state = state
+}
+
+// SetCreated sets the created flag to true once container is created
+func (c *Container) SetCreated() {
+	c.created = true
+}
+
+// Created returns whether the container was created successfully
+func (c *Container) Created() bool {
+	return c.created
 }

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -738,6 +738,8 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 
 	s.ContainerStateToDisk(container)
 
+	container.SetCreated()
+
 	resp := &pb.CreateContainerResponse{
 		ContainerId: containerID,
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -85,6 +85,10 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	}
 
 	for _, ctr := range ctrList {
+		// Skip over containers that are still being created
+		if !ctr.Created() {
+			continue
+		}
 		podSandboxID := ctr.Sandbox()
 		cState := s.Runtime().ContainerStatus(ctr)
 		created := cState.Created.UnixNano()

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -64,6 +64,10 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 	}
 
 	for _, sb := range podList {
+		// skip sandboxes that aren't created yet
+		if !sb.Created() {
+			continue
+		}
 		podInfraContainer := sb.InfraContainer()
 		if podInfraContainer == nil {
 			// this can't really happen, but if it does because of a bug

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -809,6 +809,8 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	}
 	sb.AddIP(ip)
 
+	sb.SetCreated()
+
 	resp = &pb.RunPodSandboxResponse{PodSandboxId: id}
 	logrus.Debugf("RunPodSandboxResponse: %+v", resp)
 	return resp, nil

--- a/server/server.go
+++ b/server/server.go
@@ -148,37 +148,72 @@ func (s *Server) restore() {
 	pods := map[string]*storage.RuntimeContainerMetadata{}
 	podContainers := map[string]*storage.RuntimeContainerMetadata{}
 	names := map[string][]string{}
-	for _, container := range containers {
-		metadata, err2 := s.StorageRuntimeServer().GetContainerMetadata(container.ID)
+	deletedPods := map[string]bool{}
+	for i := range containers {
+		metadata, err2 := s.StorageRuntimeServer().GetContainerMetadata(containers[i].ID)
 		if err2 != nil {
-			logrus.Warnf("error parsing metadata for %s: %v, ignoring", container.ID, err2)
+			logrus.Warnf("error parsing metadata for %s: %v, ignoring", containers[i].ID, err2)
 			continue
 		}
-		names[container.ID] = container.Names
+		names[containers[i].ID] = containers[i].Names
 		if metadata.Pod {
-			pods[container.ID] = &metadata
+			pods[containers[i].ID] = &metadata
 		} else {
-			podContainers[container.ID] = &metadata
+			podContainers[containers[i].ID] = &metadata
 		}
 	}
-	for containerID, metadata := range pods {
-		if err = s.LoadSandbox(containerID); err != nil {
-			logrus.Warnf("could not restore sandbox %s container %s: %v", metadata.PodID, containerID, err)
-			for _, n := range names[containerID] {
-				s.Store().DeleteContainer(n)
+
+	// Go through all the pods and check if it can be restored. If an error occurs, delete the pod and any containers
+	// associated with it. Release the pod and container names as well.
+	for sbID, metadata := range pods {
+		if err = s.LoadSandbox(sbID); err == nil {
+			continue
+		}
+		logrus.Warnf("could not restore sandbox %s container %s: %v", metadata.PodID, sbID, err)
+		for _, n := range names[sbID] {
+			s.Store().DeleteContainer(n)
+			// Release the infra container name and the pod name for future use
+			if strings.Contains(n, infraName) {
+				s.ReleaseContainerName(n)
+			} else {
+				s.ReleasePodName(n)
+			}
+
+		}
+		// Go through the containers and delete any container that was under the deleted pod
+		logrus.Warnf("deleting all containers under sandbox %s since it could not be restored", sbID)
+		for k, v := range podContainers {
+			if v.PodID == sbID {
+				for _, n := range names[k] {
+					s.Store().DeleteContainer(n)
+					// Release the container name for future use
+					s.ReleaseContainerName(n)
+				}
 			}
 		}
+		// Add the pod id to the list of deletedPods so we don't try to restore IPs for it later on
+		deletedPods[sbID] = true
 	}
+
+	// Go through all the containers and check if it can be restored. If an error occurs, delete the conainer and
+	// release the name associated with you.
 	for containerID := range podContainers {
 		if err := s.LoadContainer(containerID); err != nil {
 			logrus.Warnf("could not restore container %s: %v", containerID, err)
 			for _, n := range names[containerID] {
 				s.Store().DeleteContainer(n)
+				// Release the container name
+				s.ReleaseContainerName(n)
 			}
 		}
 	}
+
 	// Restore sandbox IPs
 	for _, sb := range s.ListSandboxes() {
+		// Move on if pod was deleted
+		if ok := deletedPods[sb.ID()]; ok {
+			continue
+		}
 		ip, err := s.getSandboxIP(sb)
 		if err != nil {
 			logrus.Warnf("could not restore sandbox IP for %v: %v", sb.ID(), err)


### PR DESCRIPTION
Cherry-pick https://github.com/cri-o/cri-o/pull/2319
for https://igneous.atlassian.net/browse/IG-17336.

When cri-o dies before saving the container state or fails to start the container, we leave the container metadata around to reload it on restart but don't check for errors loading the state, 
https://github.com/cri-o/cri-o/blob/release-1.11/lib/container_server.go#L565

That fails the container status calls from kubelet and blocks subsequent SyncPod()  to re-run the container, I was able to repro and verify this scenario.

Also Cherry-pick https://github.com/cri-o/cri-o/pull/1801 for various CreatedAt errors fetching status while container was being created.